### PR TITLE
Implement Vidos Universal Resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
+        "did-resolver": "4.1.0",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "tsc-alias": "^1.8.8",
     "tsconfig-paths": "^3.14.2",
     "typechain": "^8.1.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "did-resolver": "4.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * as auth from '@lib/auth/auth';
 export * as resolver from '@lib/state/resolver';
+export { default as VidosResolver } from '@lib/state/vidosResolver';
 export * as protocol from '@lib/types-sdk';
 export { core } from '@0xpolygonid/js-sdk';

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -1,0 +1,133 @@
+/* eslint-disable prettier/prettier */
+import { Id } from '@iden3/js-iden3-core';
+import { type IStateResolver, type ResolvedState, isGenesisStateId } from './resolver';
+import type { DIDDocument, DIDResolutionResult, VerificationMethod } from 'did-resolver';
+
+/**
+ * Extended DID resolution result that includes additional information about Polygon ID resolution.
+ */
+type PolygonDidResolutionResult = DIDResolutionResult & {
+  didDocument: DIDDocument & {
+    verificationMethod: (VerificationMethod & {
+      info: {
+        id: string;
+        state: string;
+        replacedByState: string;
+        createdAtTimestamp: string;
+        replacedAtTimestamp: string;
+        createdAtBlock: string;
+        replacedAtBlock: string;
+      };
+      global: {
+        root: string;
+        replacedByRoot: string;
+        createdAtTimestamp: string;
+        replacedAtTimestamp: string;
+        createdAtBlock: string;
+        replacedAtBlock: string;
+      };
+    })[];
+  };
+};
+
+/**
+ * Implementation of {@link IStateResolver} that uses Vidos resolver service to resolve states.
+ * It can serve as drop-in replacement for EthStateResolver.
+ */
+export default class VidosResolver implements IStateResolver {
+  constructor(private readonly resolverUrl: string, private readonly apiKey: string, private readonly network: 'main' | 'mumbai' | 'amoy' = 'main') {}
+
+  // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract.
+  // The only difference is the usage of regular HTTP requests instead of web3 calls.
+
+  async rootResolve(state: bigint): Promise<ResolvedState> {
+    const stateHex = state.toString(16);
+
+    const zeroAddress = '11111111111111111111'; // 1 is 0 in base58
+    const did = `did:polygonid:polygon:${this.network}:${zeroAddress}?gist=${stateHex}`;
+
+    const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(did)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+    const result = (await response.json()) as PolygonDidResolutionResult;
+    if (result.didResolutionMetadata.error) {
+      throw new Error(`error resolving DID: ${result.didResolutionMetadata.error}`);
+    }
+
+    const globalInfo = result.didDocument.verificationMethod[0].global;
+    if (globalInfo == null) throw new Error('gist info not found');
+
+    if (globalInfo.root !== stateHex) {
+      throw new Error('gist info contains invalid state');
+    }
+
+    if (globalInfo.replacedByRoot !== '0') {
+      if (globalInfo.replacedAtTimestamp === '0') {
+        throw new Error('state was replaced, but replaced time unknown');
+      }
+      return {
+        latest: false,
+        state: state,
+        transitionTimestamp: globalInfo.replacedAtTimestamp,
+        genesis: false
+      };
+    }
+
+    return {
+      latest: true,
+      state: state,
+      transitionTimestamp: 0,
+      genesis: false
+    };
+  }
+
+  async resolve(id: bigint, state: bigint): Promise<ResolvedState> {
+    const iden3Id = Id.fromBigInt(id);
+    const stateHex = state.toString(16);
+
+    const did = `did:polygonid:polygon:${this.network}:${iden3Id.string()}`;
+
+    const didWithState = `${did}?state=${stateHex}`;
+    const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(didWithState)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+    const result = (await response.json()) as PolygonDidResolutionResult;
+    if (result.didResolutionMetadata.error) {
+      throw new Error(`error resolving DID: ${result.didResolutionMetadata.error}`);
+    }
+
+    const isGenesis = isGenesisStateId(id, state);
+
+    const stateInfo = result.didDocument.verificationMethod[0].info;
+    if (stateInfo == null) throw new Error('state info not found');
+
+    if (stateInfo.id !== did) {
+      throw new Error(`state was recorded for another identity`);
+    }
+
+    if (stateInfo.state !== stateHex) {
+      if (stateInfo.replacedAtTimestamp === '0') {
+        throw new Error(`no information about state transition`);
+      }
+      return {
+        latest: false,
+        genesis: false,
+        state: state,
+        transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp)
+      };
+    }
+
+    return {
+      latest: stateInfo.replacedAtTimestamp === '0',
+      genesis: isGenesis,
+      state,
+      transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp)
+    };
+  }
+}

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -33,8 +33,33 @@ type PolygonDidResolutionResult = DIDResolutionResult & {
 /**
  * Implementation of {@link IStateResolver} that uses Vidos resolver service to resolve states.
  * It can serve as drop-in replacement for EthStateResolver.
+ * 
+ * - Vidos info: [https://vidos.id/](https://vidos.id/).
+ * - Vidos Dashboard: [https://dashboard.vidos.id/](https://dashboard.vidos.id/).
+ * - Vidos Docs: [https://vidos.id/docs/](https://vidos.id/docs/).
+ * - Quick Start Guide - Create a resolver instance: [https://vidos.id/docs/services/resolver/guides/create-instance/](https://vidos.id/docs/services/resolver/guides/create-instance/)
+ * 
+ * @example
+ * ```typescript
+ * const resolver = new VidosResolver('https://my-resolver-123.resolver.service.eu.vidos.id', 'my-api-key');
+ * 
+ * const resolvers = {
+ *   ["polygon:main"]: vidosResolver,
+ * };
+ * 
+ * const verifier = await auth.Verifier.newVerifier({ stateResolver: resolvers, circuitsDir: path.join(__dirname, keyDIR), ipfsGatewayURL: "https://ipfs.io" });
+ * ```
  */
 export default class VidosResolver implements IStateResolver {
+  
+  /**
+   * Create a new VidosResolver instance.
+   * 
+   * @param resolverUrl The URL of the Vidos resolver service to use.
+   * @param apiKey The API key to use for authentication.
+   * @param network The Polygon ID network to use. Default is 'main'.
+   * 
+   */
   constructor(private readonly resolverUrl: string, private readonly apiKey: string, private readonly network: 'main' | 'mumbai' | 'amoy' = 'main') {}
 
   // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract.


### PR DESCRIPTION
This PR increases the flexibility for verifiers that use PolygonID for credential verification by providing implementation to use Vidos Universal Resolver as an option as the state resolver.
Using the Vidos Universal Resolver, verifiers don’t need to define RPC endpoints for resolution, and can resolve all major DID methods seamlessly (e.g. did:ethr, did:ebsi, did:cheqd etc.).

### Implementation overview:

The implementation for the `VidosResolver` closely resembles the one of [`EthStateResolver`](https://github.com/iden3/js-iden3-auth/blob/ae2a69a764faf035d94349efd145022d016e0aaa/src/state/resolver.ts#L22) with the difference of how the communication with the smart contract is made and how the state is aquired.

### Other:

Example usage of `VidosResolver` is described in https://github.com/0xPolygonID/tutorial-examples/pull/33